### PR TITLE
Fixes for mobile CSS issues

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,7 +1,7 @@
 #root {
   max-width: 1280px;
   margin: 0 auto;
-  padding: 2rem;
+  padding: 1.5rem;
   text-align: center;
 }
 
@@ -34,7 +34,12 @@
 }
 
 .card {
-  padding: 2em;
+  padding: 0;
+}
+
+.card img {
+  width: 100%;
+  border-radius: 10px;
 }
 
 .read-the-docs {

--- a/src/index.css
+++ b/src/index.css
@@ -14,6 +14,12 @@
   -webkit-text-size-adjust: 100%;
 }
 
+* {
+  padding: 0;
+  margin: 0;
+  border: 0;
+}
+
 a {
   font-weight: 500;
   color: #646cff;
@@ -24,9 +30,8 @@ a:hover {
 }
 
 body {
-  margin: 0;
-  display: flex;
-  place-items: center;
+  position: absolute;
+  top: 0;
   min-width: 320px;
   min-height: 100vh;
 }


### PR DESCRIPTION
## Added
- `.card img` CSS class for manipulating images inside cards
- `width: 100%` for img inside `.card` container to stop image from rendering at original size
- `border-radius` to img inside `.card` container for a rounded appearance
- 0 value on `*` for padding, border, margin. This stops unwanted inheritance of default browser settings for these values
- `position: absolute` to the body to stop vite from generating ~ 10% of vh whitespace

## Changed
- `root` ID padding to `1.5rem` from `2.0rem` for less whitespace

## Removed
- `flex` attribute on `body` tag to stop body from expanding off-screen
- `padding` on the card to remove useless whitespace